### PR TITLE
Add testcase of platform_linux_amd64.

### DIFF
--- a/Cases/Specstest/platform_linux_amd64/Specstest-paltform_linux_amd64-runc.json
+++ b/Cases/Specstest/platform_linux_amd64/Specstest-paltform_linux_amd64-runc.json
@@ -1,0 +1,55 @@
+{
+        "Name": "Specstest-platform_linux_amd64-runc",
+        "Summary": "test based opencontainers/specs",
+        "Owner": "linzhinan@huawei.com",
+        "Description": "Test runc when linuxspec.Spec.Platform.OS = linux, linuxspec.Spec.Platform.Arch = amd64",
+        "Group": "Specstest/platform_linux_amd64/",
+        "License": "Apache 2.0",
+        "Explains" "Test runc when linuxspec.Spec.Platform.OS = linux, linuxspec.Spec.Platform.Arch = amd64 "
+        "Source": [
+	       "./source/platform_linux_amd64_host.go",
+                    "./source/demo.go"
+                    "./source/test_linux_amd64.sh"
+        ],
+        "Requires": [
+            {
+                
+	       "Class":"operationOS", 
+	        "Type": "os",
+	        "Distribution": "Ubuntu14.04",
+	        "Resource": {
+	            "CPU": 4,
+	            "Memory": "16GB",
+	            "Disk": "200G"
+	        }
+                
+            }
+            {
+                
+                "Class": "specstest",
+                "Type": "container",
+                "Version": "runc V0.2",
+            }
+        ],
+        "Deploys": [
+            {
+                "Object": "hostA",
+                "Class": "OperationOS",
+                "Cmd": "cd ./source/ ; go build platform_linux_amd64_host.go ; ./platform_linux_amd64_host ; ./test_linux_amd64.sh > /tmp/testtool/platform_linux_amd64_out.txt",
+                "Containers": [
+                    {
+                        "Object": "specs",
+                        "Class": "specstest"
+                    }
+                ]
+            }         
+        ],
+        "Collect": [
+            {
+                "Object": "hostA",
+                "Files": ["/tmp/testtool/platform_linux_amd64_out.txt"]
+            }
+        ]
+    
+}
+

--- a/Cases/Specstest/platform_linux_amd64/source/demo.go
+++ b/Cases/Specstest/platform_linux_amd64/source/demo.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("runc ran!")
+}

--- a/Cases/Specstest/platform_linux_amd64/source/platform_linux_amd64_host.go
+++ b/Cases/Specstest/platform_linux_amd64/source/platform_linux_amd64_host.go
@@ -1,0 +1,59 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	configconvert "./../../source/configconvert"
+	hostsetup "./../../source/hostsetup"
+	"fmt"
+	specs "github.com/opencontainers/specs"
+	"log"
+)
+
+func testPlatform() {
+	programmeString := "demo"
+	outputFile := ""
+	err := hostsetup.SetupEnv(programmeString, outputFile)
+	if err != nil {
+		log.Fatalf("Specstest platform linux amd64 test: hostsetup.SetupEnv error, %v", err)
+	}
+	fmt.Println("Host enviroment setting up for runc is already!")
+	var filePath string
+	filePath = "./../../source/config.json"
+
+	oriSpecVersion := specs.Version
+	var linuxspec *specs.LinuxSpec
+	linuxspec, err = configconvert.ConfigToLinuxSpec(filePath)
+	if err != nil {
+		log.Fatalf("Specstest platform linux amd64 test: readconfig error, %v", err)
+	}
+
+	linuxspec.Spec.Root.Path = "./rootfs_rootconfig"
+	linuxspec.Spec.Version = oriSpecVersion
+	linuxspec.Spec.Platform.OS = "linux"
+	linuxspec.Spec.Platform.Arch = "amd64"
+	linuxspec.Spec.Process.Args[0] = "./" + programmeString
+	err = configconvert.LinuxSpecToConfig(filePath, linuxspec)
+
+	if err != nil {
+		log.Fatalf("Specstest platform linux amd64 test: writeconfig error, %v", err)
+	}
+	fmt.Println("Host enviroment for runc is already!")
+
+}
+
+func main() {
+	testPlatform()
+}

--- a/Cases/Specstest/platform_linux_amd64/source/test_linux_amd64.sh
+++ b/Cases/Specstest/platform_linux_amd64/source/test_linux_amd64.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd ./../../source/ ; runc
+if [ $? -eq 0 ]; then
+	echo "[YES]        linuxspec.Spec.Platform.OS = "linux"     linuxspec.Spec.Platform.Arch = "amd64"   passed"
+else 
+	echo "[NO]        linuxspec.Spec.Platform.OS = "linux"     linuxspec.Spec.Platform.Arch = "amd64"   failed"
+fi
+
+

--- a/Cases/Specstest/source/config.json
+++ b/Cases/Specstest/source/config.json
@@ -12,7 +12,7 @@
       "additionalGids": null
     },
     "args": [
-      "bash"
+      "./demo"
     ],
     "env": [
       "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
@@ -75,6 +75,10 @@
       "options": "nosuid,noexec,nodev,relatime,ro"
     }
   ],
+  "hooks": {
+    "prestart": null,
+    "poststop": null
+  },
   "linux": {
     "uidMappings": null,
     "gidMappings": null,
@@ -139,14 +143,13 @@
       "KILL",
       "NET_BIND_SERVICE"
     ],
- "devices": [
-            "null",
-            "random",
-            "full",
-            "tty",
-            "zero",
-            "urandom"
-        ],
+    "devices": null,
+    "apparmorProfile": "",
+    "selinuxProcessLabel": "",
+    "seccomp": {
+      "defaultAction": "",
+      "syscalls": null
+    },
     "rootfsPropagation": ""
   }
 }


### PR DESCRIPTION
Add testcase of platform_linux_amd64.
Temporary change devices of config.json to be null, because of runc unsupportted yet.

Signed-off-by: LinZhinan(Zen Lin) <linzhinan@huawei.com>