### PR TITLE
Temporarily use the local way to call pkg.

### DIFF
--- a/cases/benchmark/monitor/dockercpumonitor/source/cpu_usage.go
+++ b/cases/benchmark/monitor/dockercpumonitor/source/cpu_usage.go
@@ -17,7 +17,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	adaptor "github.com/huawei-openlab/oct/blob/master/Cases/Benchmark/monitor/source/adaptor"
+	adaptor "./../../source/adaptor"
 	//"fmt"
 	"github.com/google/cadvisor/client"
 	info "github.com/google/cadvisor/info/v1"

--- a/cases/benchmark/monitor/rktcpumonitor/source/cpu_usage.go
+++ b/cases/benchmark/monitor/rktcpumonitor/source/cpu_usage.go
@@ -17,7 +17,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	adaptor "github.com/huawei-openlab/oct/blob/master/Cases/Benchmark/monitor/source/adaptor"
+	adaptor "./../../source/adaptor"
 	//"fmt"
 	"github.com/google/cadvisor/client"
 	info "github.com/google/cadvisor/info/v1"


### PR DESCRIPTION
 Change the call of the public pkg using the local way but not github way.
 Temporary versioin, because of the unsupportted by the framework.
Signed-off-by: LinZhinan(Zen Lin) <linzhinan@huawei.com>