### PR TITLE
Correct ocitd.go when run cmd, export the stderr/stdin/stdout of the exec.Command.

### DIFF
--- a/engine/ocitd/ocitd.go
+++ b/engine/ocitd/ocitd.go
@@ -97,7 +97,7 @@ func RunCommand(cmd string, dir string) {
 		c.Stderr = os.Stderr
 		c.Stdout = os.Stdout
 		c.Stdin = os.Stdin
-		if err := cmd.Run(); err != nil {
+		if err := c.Run(); err != nil {
 			log.Fatalf("Ocitd run cmd %v error", cmd)
 		}
 	} else {

--- a/engine/ocitd/ocitd.go
+++ b/engine/ocitd/ocitd.go
@@ -13,7 +13,7 @@ import (
 	"os/exec"
 	"path"
 
-//	"strings"
+	//	"strings"
 )
 
 /*
@@ -94,7 +94,12 @@ func RunCommand(cmd string, dir string) {
 	debugging := true
 	if debugging {
 		c := exec.Command("/bin/sh", "-c", cmd)
-		c.Run()
+		c.Stderr = os.Stderr
+		c.Stdout = os.Stdout
+		c.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			log.Fatalf("Ocitd run cmd %v error", cmd)
+		}
 	} else {
 		C.CSystem(C.CString(cmd))
 	}


### PR DESCRIPTION
Correct ocitd.go when run cmd, export the stderr/stdin/stdout of the exec.Command.

Signed-off-by: LinZhinan(Zen Lin) <linzhinan@huawei.com>