### PR TITLE
Fix bug of SetRight, enable chown with the sub files in containerend.

### DIFF
--- a/tools/specsValidator/utils/set_right.go
+++ b/tools/specsValidator/utils/set_right.go
@@ -11,8 +11,19 @@ func SetRight(file string, uid int32, gid int32) {
 		log.Fatalf("Open file %v error %v", file, err)
 	}
 	defer f.Close()
+
 	err = f.Chown(int(uid), int(gid))
 	if err != nil {
 		log.Fatalf("Chown file %v error %v", file, err)
+	}
+
+	// Read all files under file
+	ff, _ := f.Readdirnames(0)
+	for _, fi := range ff {
+		subFile := file + "/" + fi
+		err = os.Chown(subFile, int(uid), int(gid))
+		if err != nil {
+			log.Fatalf("Chown file %v error %v", subFile, err)
+		}
 	}
 }


### PR DESCRIPTION
Fix bug of SetRight, enable chown with the sub files in containerend.
Signed-off-by: LinZhinan(Zen Lin) <linzhinan@huawei.com>