### PR TITLE
 Add creating func of minimunset of objs(linuxspec and linuxruntime), can be called in cases, to avoid repeat init of structs.

### DIFF
--- a/tools/specsValidator/utils/specsinit/minimumlinuxruntimeinit_v0.1.1.go
+++ b/tools/specsValidator/utils/specsinit/minimumlinuxruntimeinit_v0.1.1.go
@@ -1,0 +1,35 @@
+// +build v0.1.1
+
+package specsinit
+
+import (
+	"github.com/opencontainers/specs"
+)
+
+func SetLinuxruntimeMinimum() specs.LinuxRuntimeSpec {
+	var linuxRuntime specs.LinuxRuntimeSpec = specs.LinuxRuntimeSpec{
+		Linux: specs.LinuxRuntime{
+			Resources: &specs.Resources{
+				Memory: specs.Memory{
+					Swappiness: -1,
+				},
+			},
+			Namespaces: []specs.Namespace{
+				{
+					Type: "mount",
+					Path: "",
+				},
+			},
+		},
+		RuntimeSpec: specs.RuntimeSpec{
+			Mounts: map[string]specs.Mount{
+				"proc": {
+					Type:    "proc",
+					Source:  "proc",
+					Options: []string{""},
+				},
+			},
+		},
+	}
+	return linuxRuntime
+}

--- a/tools/specsValidator/utils/specsinit/minimumlinuxruntimeinit_v0.1.1_test.go
+++ b/tools/specsValidator/utils/specsinit/minimumlinuxruntimeinit_v0.1.1_test.go
@@ -1,0 +1,29 @@
+// +build v0.1.1
+
+package specsinit
+
+import (
+	"github.com/huawei-openlab/oct/tools/specsValidator/utils/configconvert"
+	"testing"
+)
+
+func TestSetLinuxruntimeMinimum(t *testing.T) {
+	lr := SetLinuxruntimeMinimum()
+	filePath := "runtime.json"
+	err := configconvert.LinuxRuntimeToConfig(filePath, &lr)
+	if err != nil {
+		t.Errorf("specsinit SetLinuxruntimeMinimum err %v", err)
+	} else {
+		lrn, err := configconvert.ConfigToLinuxRuntime(filePath)
+		if err != nil {
+			t.Errorf("specsinit SetLinuxruntimeMinimum err %v", err)
+		} else {
+			if lrn.Linux.Resources.Memory.Swappiness == -1 {
+				t.Log("specsinit SetLinuxruntimeMinimum successful!")
+			} else {
+				t.Error("specsinit SetLinuxruntimeMinimum err get wrong value from obj")
+			}
+		}
+	}
+
+}

--- a/tools/specsValidator/utils/specsinit/minimumlinuxspecinit_v0.1.1.go
+++ b/tools/specsValidator/utils/specsinit/minimumlinuxspecinit_v0.1.1.go
@@ -1,0 +1,44 @@
+// +build v0.1.1
+
+package specsinit
+
+import (
+	"github.com/opencontainers/specs"
+	"runtime"
+)
+
+func SetLinuxspecMinimum() specs.LinuxSpec {
+	var linuxSpec specs.LinuxSpec = specs.LinuxSpec{
+		Spec: specs.Spec{
+			Version: "0.1.0",
+			Platform: specs.Platform{
+				OS:   runtime.GOOS,
+				Arch: runtime.GOARCH,
+			},
+			Root: specs.Root{
+				Path:     "rootfs",
+				Readonly: true,
+			},
+			Process: specs.Process{
+				Terminal: false,
+				User: specs.User{
+					UID:            0,
+					GID:            0,
+					AdditionalGids: nil,
+				},
+				Args: []string{""},
+				Env:  []string{""},
+				Cwd:  "",
+			},
+			Hostname: "zenlinHost",
+			Mounts: []specs.MountPoint{
+				{
+					Name: "proc",
+					Path: "/proc",
+				},
+			},
+		},
+	}
+
+	return linuxSpec
+}

--- a/tools/specsValidator/utils/specsinit/minimumlinuxspecinit_v0.1.1_test.go
+++ b/tools/specsValidator/utils/specsinit/minimumlinuxspecinit_v0.1.1_test.go
@@ -1,0 +1,29 @@
+// +build v0.1.1
+
+package specsinit
+
+import (
+	"github.com/huawei-openlab/oct/tools/specsValidator/utils/configconvert"
+	"testing"
+)
+
+func TestSetLinuxspecMinimum(t *testing.T) {
+	ls := SetLinuxspecMinimum()
+	filePath := "config.json"
+	err := configconvert.LinuxSpecToConfig(filePath, &ls)
+	if err != nil {
+		t.Errorf("Configset TestConfigminimumset err %v", err)
+	} else {
+		lsn, err := configconvert.ConfigToLinuxSpec(filePath)
+		if err != nil {
+			t.Errorf("Configset TestConfigminimumset err %v", err)
+		} else {
+			if lsn.Hostname == "zenlinHost" {
+				t.Log("Configset TestConfigminimumset successful!")
+			} else {
+				t.Error("Configset TestConfigminimumset err get wrong value from obj")
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
 Add creating func of minimunset of objs(linuxspec and linuxruntime), can be called in cases, to avoid repeat init of structs.

Signed-off-by: LinZhinan(Zen Lin) <linzhinan@huawei.com>