### PR TITLE
Adjust the specprocess testcase to the opencontainers/specs, about type of AdditionlGids from []int32 to []uint32.

### DIFF
--- a/tools/runtimeValidator/cases/specprocess/test_process_v0.1.1.go
+++ b/tools/runtimeValidator/cases/specprocess/test_process_v0.1.1.go
@@ -34,7 +34,7 @@ func TestUser1000() string {
 		User: specs.User{
 			UID:            1000,
 			GID:            1000,
-			AdditionalGids: []int32{0, 1000},
+			AdditionalGids: []uint32{0, 1000},
 		},
 		Args: []string{"./specprocess"},
 		Env:  nil,
@@ -54,7 +54,7 @@ func TestUser1() string {
 		User: specs.User{
 			UID:            1,
 			GID:            1,
-			AdditionalGids: []int32{0},
+			AdditionalGids: []uint32{0},
 		},
 		Args: []string{"./specprocess"},
 		Env:  nil,

--- a/tools/runtimeValidator/specs_v0.1.1.go
+++ b/tools/runtimeValidator/specs_v0.1.1.go
@@ -31,7 +31,7 @@ import (
 	//_ "github.com/huawei-openlab/oct/tools/runtimeValidator/cases/linuxuidgidmappings"
 	_ "github.com/huawei-openlab/oct/tools/runtimeValidator/cases/specmount"
 	_ "github.com/huawei-openlab/oct/tools/runtimeValidator/cases/specplatform"
-	//_ "github.com/huawei-openlab/oct/tools/runtimeValidator/cases/specprocess"
+	_ "github.com/huawei-openlab/oct/tools/runtimeValidator/cases/specprocess"
 	_ "github.com/huawei-openlab/oct/tools/runtimeValidator/cases/specroot"
 	"github.com/huawei-openlab/oct/tools/runtimeValidator/hostenv"
 	"github.com/huawei-openlab/oct/tools/runtimeValidator/manager"


### PR DESCRIPTION
Adjust the specprocess testcase to the opencontainers/specs, about type of AdditionlGids from []int32 to []uint32.

Signed-off-by: linzhinan <linzhinan@huawei.com>