### PR TITLE
add wait to prevent defunct

### DIFF
--- a/utils/cmd.go
+++ b/utils/cmd.go
@@ -41,6 +41,12 @@ func ExecCmd(path string, arg1 string, args ...string) (string, error) {
 		retStr = string(retb)
 	}
 
+	err = cmd.Wait()
+	if err != nil {
+		retb, _ := ioutil.ReadAll(stderr)
+		retStr = string(retb)
+	}
+
 	return retStr, err
 }
 


### PR DESCRIPTION
Signed-off-by: liangchenye <liangchenye@huawei.com>

Without 'wait', the process called in 'ExecCmd' will become a 'defunct' process until their parent process exit.
It may not visible in oct as their parent process 'ocitest' will exit any way.
